### PR TITLE
Adjust buffers to meet Query Monitor output

### DIFF
--- a/conf/nginx/php-fpm.conf
+++ b/conf/nginx/php-fpm.conf
@@ -25,6 +25,6 @@ include server_name.conf;
 fastcgi_param HTTPS $use_ssl;
 
 # configure buffers
-fastcgi_buffers 32 32k;
-fastcgi_buffer_size 64k;
-fastcgi_busy_buffers_size 64k;
+fastcgi_buffers 16 64k;
+fastcgi_buffer_size 128k;
+fastcgi_busy_buffers_size 128k;


### PR DESCRIPTION
Increases the buffer size to allow Query Monitor to send large headers