### PR TITLE
CDPT-730 Running out of memory

### DIFF
--- a/conf/nginx/php-fpm.conf
+++ b/conf/nginx/php-fpm.conf
@@ -25,6 +25,6 @@ include server_name.conf;
 fastcgi_param HTTPS $use_ssl;
 
 # configure buffers
-fastcgi_buffers 32 32k;
-fastcgi_buffer_size 64k;
-fastcgi_busy_buffers_size 64k;
+fastcgi_buffers 16 64k;
+fastcgi_buffer_size 128k;
+fastcgi_busy_buffers_size 128k;

--- a/conf/php-fpm/php.ini
+++ b/conf/php-fpm/php.ini
@@ -386,7 +386,7 @@ max_input_time = 60
 
 ; Maximum amount of memory a script may consume (128MB)
 ; http://php.net/memory-limit
-memory_limit = 128M
+memory_limit = 256M
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Error handling and logging ;


### PR DESCRIPTION
Sentry reported a fatal error in Production on the morning of Monday, 22nd May.

https://ministryofjustice.sentry.io/issues/4199284625/?environment=production&project=6143405&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=5

 Error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 99578120 bytes)

**The request that caused it:**

https://intranet.justice.gov.uk:80/documents/2022/09/all-upoa-cases-by-provider.xlsb/

**Probable cause:**

[The file](https://intranet.justice.gov.uk/wp/wp-admin/post.php?post=397772&action=edit) is being read into memory, and the size of the file is bigger than the allocated memory allowed = **128MB**.

Generally, this type of error would indicate a problem in code; however, it would seem different in this case as the contents of a file are being compressed to `gzip` before being sent to the browser - this is when the error occurs. It is worth noting the Intranet upload limit is **256MB**.

Under this circumstance, memory will be exhausted should a file size exceed the allowed limit.