### PR TITLE
Increase PHP memory_limit to 384MB

### DIFF
--- a/conf/php-fpm/php.ini
+++ b/conf/php-fpm/php.ini
@@ -386,7 +386,7 @@ max_input_time = 60
 
 ; Maximum amount of memory a script may consume (128MB)
 ; http://php.net/memory-limit
-memory_limit = 256M
+memory_limit = 384M
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Error handling and logging ;


### PR DESCRIPTION
**File download failed for the user concerning this file:**
https://intranet.justice.gov.uk/documents/2022/04/learning-at-work-week-guide.docx/

This PR fixed the issue and allowed the file to be downloaded. Further investigation is underway to understand why PHP8.2 presents us with these memory issues. Some early findings suggest the just-in-time compiler is stricter on memory allocation.

**Error:**
```
Error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 98692136 bytes)
```

**Reported in Sentry:**
https://ministryofjustice.sentry.io/issues/4199284625/?project=6143405&referrer=regression_activity-email

**Context:**
Users can upload files maxing 200MB, which has a knock-on effect on memory management in PHP. A notable change in the recent update to PHP8.2 is memory management and the JIT compiler presenting some bugs - fixed in our version but may still have an impact.

**Some info on _memory-related_ updates in PHP8.2**
https://php.watch/versions/8.2#memory_reset_peak_usage


