### PR TITLE
CDPT-963 Account for large cookies: increase client header size

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml

--- a/.idea/intranet-base-docker.iml
+++ b/.idea/intranet-base-docker.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
-  <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/intranet-base-docker.iml" filepath="$PROJECT_DIR$/.idea/intranet-base-docker.iml" />
-    </modules>
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/conf/nginx/server.conf
+++ b/conf/nginx/server.conf
@@ -24,7 +24,7 @@ server {
 	root /bedrock/web;
 	index index.php;
 
-    large_client_header_buffers 4 16k;
+	large_client_header_buffers 4 16k;
 	client_max_body_size 250m;
 
 	# Check and enable RealIP

--- a/conf/nginx/server.conf
+++ b/conf/nginx/server.conf
@@ -24,7 +24,6 @@ server {
 	root /bedrock/web;
 	index index.php;
 
-	large_client_header_buffers 4 16k;
 	client_max_body_size 250m;
 
 	# Check and enable RealIP

--- a/conf/nginx/server.conf
+++ b/conf/nginx/server.conf
@@ -24,6 +24,7 @@ server {
 	root /bedrock/web;
 	index index.php;
 
+    large_client_header_buffers 4 16k;
 	client_max_body_size 250m;
 
 	# Check and enable RealIP


### PR DESCRIPTION
**Context**
PR in response to the error detailed here: https://github.com/ministryofjustice/intranet/pull/456

The release increases the `client_header` size ***from 8kb to 16kb*** to account for large cookie values created by AWS auth tokens, Query Monitor and the tree-view plugin.

**Note**
An IDE-specific directory was present. This was also removed in this PR.